### PR TITLE
VR: finish VrStereoOffAxis for plain-stereo hardware (cursor, RTT panels, Vulkan 2D layer)

### DIFF
--- a/src/falclib/include/f4find.h
+++ b/src/falclib/include/f4find.h
@@ -21,7 +21,7 @@
 #include <windows.h>
 #endif
 
-#define FALCON_REGISTRY_KEY "Software\\MicroProse\\Falcon\\4.0"
+#define FALCON_REGISTRY_KEY "Software\\MicroProse\\Falcon\\4.1"
 
 extern char FalconDataDirectory[_MAX_PATH];
 extern char FalconTerrainDataDir[_MAX_PATH];

--- a/src/sim/include/datadir.h
+++ b/src/sim/include/datadir.h
@@ -1,7 +1,7 @@
 #ifndef _SETUPDAT_H
 #define _SETUPDAT_H
 
-#define FALCON_REGISTRY_KEY "Software\\MicroProse\\Falcon\\4.0"
+#define FALCON_REGISTRY_KEY "Software\\MicroProse\\Falcon\\4.1"
 
 extern char FalconDataDirectory[_MAX_PATH];
 extern char FalconTerrainDataDir[_MAX_PATH];

--- a/src/sim/otwdrive/otwloop.cpp
+++ b/src/sim/otwdrive/otwloop.cpp
@@ -2158,8 +2158,15 @@ void OTWDriverClass::RenderVulkanVR(RenderOTW* renderer, void* pHeadOrigin,
                 renderer->SetViewport(-1.0f, 1.0f, 1.0f, -1.0f);
                 g_pVulkanBackend->SetGScreenSize(gW, gH);
                 float efl, efr, efu, efd;
-                if (quad and g_pOpenXRBackend->GetEyeFovAngles(gv, &efl, &efr,
-                                                               &efu, &efd))
+                // The stage-1 multiview pass draws the world and the 3D cockpit with the runtime's TRUE
+                // off-axis per-view projection under VrStereoOffAxis, not just under quad-views. This tail
+                // pass must match it, or the RTT displays and 2D overlays are projected with a symmetric
+                // frustum onto a scene drawn off-axis -- each eye's 2D layer lands ~7 degrees out, mirrored,
+                // and the MFDs/HUD duplicate and sit away from their panels. Same class as the cursor/hit-test
+                // mismatch in vcock.cpp: whatever the 3D was drawn with, the 2D on top has to use too.
+                if ((quad or g_bVrStereoOffAxis) and
+                    g_pOpenXRBackend->GetEyeFovAngles(gv, &efl, &efr, &efu,
+                                                      &efd))
                     renderer->SetVRFrustum(efl, efr, efu, efd);
                 else
                     renderer->SetFOV(hf);

--- a/src/sim/otwdrive/otwloop.cpp
+++ b/src/sim/otwdrive/otwloop.cpp
@@ -2040,12 +2040,21 @@ void OTWDriverClass::RenderVulkanVR(RenderOTW* renderer, void* pHeadOrigin,
             // with head yaw/pitch -> the flat-canvas error rotates too -> the panels drift under head motion (absent in
             // the per-eye path, which puts the IPD in headOrigin via ownshipRot*eyeLatFeet). Both the multiview world/
             // cockpit AND this composite use worldOffs, so keeping them body-frame fixes the drift AND keeps them fused.
+            // The per-eye path this comment cites as the body-frame precedent now rotates its IPD by cameraRot
+            // (VrHeadRelIpd, vcock.cpp): the eyes are separated across the SKULL, so body-frame is only correct
+            // looking straight ahead and goes cross-eyed as the head turns -- ipd * 2sin(t/2), ~75% of the eye
+            // offset at 45 degrees of gaze. That path can have it both ways because the world camera IPD
+            // (headOrigin) and the RTT panel IPD (Pan.y * g_fVrDisplayIpd, in VCock_Exec) are SEPARATE values;
+            // here one worldOffs feeds both the stage-1 world/cockpit and the stage-2 RTT tail, so it is a real
+            // trade: head-frame fixes the gaze cross-eye, body-frame keeps the flat-canvas panel error stable.
+            // Knob so it can be measured on hardware. Default OFF = the shipped body-frame behaviour.
+            extern bool g_bVrVulkanHeadRelIpd;
             Tpoint bv;
             bv.x = 0.0f;
             bv.y = sgn * g_pOpenXRBackend->GetEyeLateralOffsetFeet(gv);
             bv.z = 0.0f;
             Tpoint wv;
-            MatrixMult(&ownshipRot, &bv, &wv);
+            MatrixMult(g_bVrVulkanHeadRelIpd ? camRot : &ownshipRot, &bv, &wv);
             worldOffs[localV * 3 + 0] = wv.x;
             worldOffs[localV * 3 + 1] = wv.y;
             worldOffs[localV * 3 + 2] = wv.z;

--- a/src/sim/otwdrive/vcock.cpp
+++ b/src/sim/otwdrive/vcock.cpp
@@ -4608,8 +4608,33 @@ void OTWDriverClass::VCock_Exec(void)
                         g_pOpenXRBackend->CurrentEye() :
                         -1;
         if (dxeye >= 0)
-            Pan.y += g_pOpenXRBackend->GetEyeLateralOffsetFeet(dxeye) *
-                     g_fVrDisplayIpd;
+        {
+            const float ipdY = g_pOpenXRBackend->GetEyeLateralOffsetFeet(
+                                   dxeye) *
+                               g_fVrDisplayIpd;
+            // Same defect as VrHeadRelIpd (world camera) and VrHeadRelCursorIpd (cursor anchor), a third time:
+            // Pan.y is the BODY-right axis, but the eyes are separated across the SKULL, so their separation
+            // rotates with the head. Body-right and head-right coincide only looking straight ahead, so the
+            // panels converge dead ahead and go cross-eyed as the head turns -- worst on the closest panels,
+            // i.e. the lower-left/lower-right consoles. Independent of g_fVrViewInstIpdSign and VrHeadRelIpd
+            // (different variable, different code path), which is why neither of those knobs moved it.
+            // Pan is cockpit/body space, so rotate the head-frame offset into it by headMatrix.
+            extern bool g_bVrHeadRelDisplayIpd;
+            if (g_bVrHeadRelDisplayIpd)
+            {
+                Tpoint bv;
+                bv.x = 0.0f;
+                bv.y = ipdY;
+                bv.z = 0.0f;
+                Tpoint wv;
+                MatrixMult(&headMatrix, &bv, &wv);
+                Pan.x += wv.x;
+                Pan.y += wv.y;
+                Pan.z += wv.z;
+            }
+            else
+                Pan.y += ipdY;
+        }
     }
     // Artscout - 2026 (VR #61): world-frame RTT panels. Draw the RTT quads with the SAME camera as the
     // BSP cockpit (headOrigin) and let DrawRttQuad map the canvas into the real cockpit world

--- a/src/sim/otwdrive/vcock.cpp
+++ b/src/sim/otwdrive/vcock.cpp
@@ -1735,18 +1735,45 @@ void OTWDriverClass::VCock_HeadCalc(void)
                 posHead.y += hpr;
                 posHead.z += hpd;
             }
-            Tpoint posCam = posHead; // camera also gets the IPD
-            if (xeye >= 0)
-                posCam.y += g_pOpenXRBackend->GetEyeLateralOffsetFeet(
-                    xeye); // IPD on body right axis
             headPan.x += posHead.x;
             headPan.y += posHead.y;
             headPan.z += posHead.z; // displays: lean only
+            // Head LEAN is a body-frame 6DOF translation -> ownshipRot, as before.
             Tpoint posW;
-            MatrixMult(&OTWDriver.ownshipRot, &posCam, &posW);
+            MatrixMult(&OTWDriver.ownshipRot, &posHead, &posW);
             headOrigin.x += posW.x;
             headOrigin.y += posW.y;
-            headOrigin.z += posW.z; // camera: lean + IPD
+            headOrigin.z += posW.z;
+            // Artscout - 2026 (gaze-dependent stereo fix): the per-eye IPD must be applied along the HEAD's
+            // right axis, NOT the aircraft's. The eyes are separated across the skull, so that separation
+            // rotates with the head; the old code added it to posCam.y (body right) and rotated by ownshipRot
+            // (the JET's orientation, which contains no head rotation). With the head aligned to the airframe
+            // body-right == head-right, so looking straight ahead was correct -- but any head yaw/pitch left
+            // the eye offset pointing the wrong way in world space, and the error grew with how far the head
+            // had turned (reported as: converges fine forward, misaligns when looking down-left/down-right at
+            // the aux panels). cameraRot = ownshipRot * headMatrix, so rotating the offset by IT gives the
+            // true world-space eye separation for the CURRENT gaze. This also makes the per-eye path agree
+            // with RenderWorldViewInstanced, which already rotates its eye offset by camRot (otwloop.cpp).
+            // g_bVrHeadRelIpd (default ON) reverts to the old body-frame behaviour if 0.
+            extern bool g_bVrHeadRelIpd;
+            if (xeye >= 0)
+            {
+                extern float g_fVrViewInstIpdSign;
+                const float ipd = g_fVrViewInstIpdSign *
+                                  g_pOpenXRBackend->GetEyeLateralOffsetFeet(
+                                      xeye);
+                Tpoint bv;
+                bv.x = 0.0f;
+                bv.y = ipd; // lateral (right) in the chosen frame
+                bv.z = 0.0f;
+                Tpoint wv;
+                MatrixMult(g_bVrHeadRelIpd ? &cameraRot :
+                                             &OTWDriver.ownshipRot,
+                           &bv, &wv);
+                headOrigin.x += wv.x;
+                headOrigin.y += wv.y;
+                headOrigin.z += wv.z; // camera: + per-eye IPD
+            }
         }
     }
 }
@@ -5242,8 +5269,23 @@ void OTWDriverClass::VCock_Exec(void)
             // left-eye stereo cant shifts the cockpit ~330px sideways), but SYMMETRIZE the vertical (offY=0):
             // [VRICP] showed the cockpit's vertical is ~symmetric, so a symmetric vertical matches best while
             // preserving the true VFOV (height tanU-tanD unchanged: angU'=-angD'=atan((tanU-tanD)/2)).
-            float vh = (float)atan((tan(cfu) - tan(cfd)) * 0.5f);
-            renderer->SetVRFrustum(cfl, cfr, vh, -vh);
+            // Artscout - 2026 (stereo off-axis fix): the hit-test MUST project with the same frustum the
+            // eye was RENDERED with, or the projected buttons sit somewhere the drawn cockpit does not.
+            // The symmetrized vertical below was correct while the per-eye path rendered a symmetric
+            // SetFOV; with g_bVrStereoOffAxis the render now uses the runtime's true, vertically-canted
+            // frustum (Quest 3: U=+44 D=-55, ~5.5 deg down), so symmetrizing here left the buttons ~10%
+            // of screen height above where they are drawn -- the "cursor is way off on Y" report. Track
+            // whatever the render actually used.
+            extern bool g_bVrStereoOffAxis;
+            if (g_bVrStereoOffAxis)
+            {
+                renderer->SetVRFrustum(cfl, cfr, cfu, cfd);
+            }
+            else
+            {
+                float vh = (float)atan((tan(cfu) - tan(cfd)) * 0.5f);
+                renderer->SetVRFrustum(cfl, cfr, vh, -vh);
+            }
         }
         renderer->SetCamera(&headOrigin, &headMatrix);
     }
@@ -5576,6 +5618,11 @@ void OTWDriverClass::VCock_Exec(void)
                 renderer->UnprojectNdc(ndcx, ndcy, &rD);
                 // DIAG confirmed: the Button3DList frame's forward is -x vs the unproject's +x (engine looks down
                 // -Z; UnTransformPoint's sz=+1 comes out reversed for our button compare). Negate so t>0.
+                // NOTE: this is a point reflection, not a frame rotation, so it mirrors right/up as well as
+                // forward -- but the DRAW path is mirrored identically, so the two cancel and the cursor
+                // tracks the mouse correctly. (Flipping only the forward axis here inverts mouse->cursor
+                // motion; tested and reverted. The off-axis aim error that looked like a mirror was in fact
+                // the cursor's stereo offset -- see the head-relative ipdOfs below.)
                 rD.x = -rD.x;
                 rD.y = -rD.y;
                 rD.z = -rD.z;
@@ -5634,15 +5681,21 @@ void OTWDriverClass::VCock_Exec(void)
                     }
                 }
 
-                // Cursor depth along the ray: on a hit -> the button depth; free-aim -> the NEAREST button's
-                // depth (dPt) so the cursor sits at the panel the user looks at. A fixed g_fVrRayReach put the
-                // free cursor CLOSER than the panel -> the two eyes saw it at different positions (per-eye
-                // disparity for the wrong depth) so it "doubled" until it snapped onto a button. Reach is only
-                // the fallback when no button is anywhere near the ray.
-                float anchorT =
-                    (bestAny >= 0) ?
-                        bestAnyT :
-                        ((dPi >= 0 and dPt > 1.0f) ? dPt : g_fVrRayReach);
+                // Artscout - 2026 (free-cursor split fix): on a HIT use the button's own depth (correct by
+                // construction). With no hit, the old code used dPt -- the nearest button's projection ALONG
+                // the ray (t = dist*cos(angle)). Aimed away from the panel that cosine collapses, so the
+                // anchor landed far nearer than the panel, giving the cursor stereo disparity for a depth
+                // nothing is at -> it split in two mid-screen (and g_fVrRayReach, the knob meant for exactly
+                // this, never applied because SOME button is always "nearest"). Use dPt only when it is
+                // actually near the panel plane; otherwise sit at the tuned reach so free-aim converges.
+                float anchorT;
+                if (bestAny >= 0)
+                    anchorT = bestAnyT;
+                else if (dPi >= 0 and dPt > g_fVrRayReach * 0.6f and
+                         dPt < g_fVrRayReach * 1.6f)
+                    anchorT = dPt;
+                else
+                    anchorT = g_fVrRayReach;
                 g_vrCursorAnchor.x = rO.x + rD.x * anchorT;
                 g_vrCursorAnchor.y = rO.y + rD.y * anchorT;
                 g_vrCursorAnchor.z = rO.z + rD.z * anchorT;
@@ -5696,7 +5749,13 @@ void OTWDriverClass::VCock_Exec(void)
             // separation comes from the camera position). But SetFOV derives the VERTICAL fov from the CURRENT
             // xRes/yRes (~16:9 during VCock_Exec), not the near-square eye the BSP was drawn into -> reproduce it
             // with the EYE aspect. QUAD: the BSP genuinely uses the off-axis per-view frustum -> pass it through.
-            if (sessionQuad)
+            // Artscout - 2026 (stereo off-axis fix): the cursor must be DRAWN through the same projection the
+            // cockpit was RENDERED with, or it lands somewhere the cockpit isn't (reported as: cursor over the
+            // left MFD, but the pick fires on the ICP). The symmetric branch below was correct while plain
+            // stereo rendered SetFOV(); with g_bVrStereoOffAxis the BSP now uses the runtime's true off-axis
+            // per-eye frustum, so mirror that here exactly as the hit-test projection already does.
+            extern bool g_bVrStereoOffAxis;
+            if (sessionQuad or g_bVrStereoOffAxis)
                 renderer->SetVRFrustum(efl, efr, efu, efd);
             else
             {
@@ -5751,10 +5810,38 @@ void OTWDriverClass::VCock_Exec(void)
         // onto them reads as "stuck / off" ("прилипание"); keeping it on the beam shows exactly where the
         // controller points. g_vrCursorAnchor already sits at the hit depth when over a button (bestAnyT),
         // else at the free reach. g_vrHitValid only picks the glyph (ring = a clickable is under the beam).
+        // Artscout - 2026 (cursor edge-accuracy fix): the eyes are separated along the HEAD's right axis, but
+        // the anchor lives in the cockpit/body frame, so adding ipdY straight onto .y offsets along the
+        // AIRFRAME's right instead. Those coincide only while the head faces forward; look down-left/down-right
+        // and the disparity is applied in the wrong direction, so the two eyes' cursors disagree by more and
+        // more the further off-axis you aim (measured: 634px apart in the lower-left corner vs ~226px centred).
+        // Rotate the lateral offset by the head orientation -- the same frame this projection is drawn with
+        // (VrSetEyeCam does SetCamera(headOrigin, headMatrix)) -- exactly as the VCock_HeadCalc camera fix does.
+        // g_bVrHeadRelCursorIpd (default ON) reverts to the body-axis behaviour if 0.
+        extern bool g_bVrHeadRelCursorIpd;
+        Tpoint ipdOfs;
+        if (g_bVrHeadRelCursorIpd)
+        {
+            Tpoint bv;
+            bv.x = 0.0f;
+            bv.y = ipdY;
+            bv.z = 0.0f;
+            MatrixMult(&headMatrix, &bv, &ipdOfs);
+        }
+        else
+        {
+            ipdOfs.x = 0.0f;
+            ipdOfs.y = ipdY;
+            ipdOfs.z = 0.0f;
+        }
         Tpoint aE = g_vrCursorAnchor;
-        aE.y += ipdY;
+        aE.x += ipdOfs.x;
+        aE.y += ipdOfs.y;
+        aE.z += ipdOfs.z;
         Tpoint oE = g_vrRayOrigin;
-        oE.y += ipdY;
+        oE.x += ipdOfs.x;
+        oE.y += ipdOfs.y;
+        oE.z += ipdOfs.z;
         ThreeDVertex tA, tO;
         renderer->TransformCameraCentricPoint(&aE, &tA);
         if (tA.csZ < -30.0f)

--- a/src/ui/src/f4config.cpp
+++ b/src/ui/src/f4config.cpp
@@ -90,6 +90,10 @@ bool g_bVrHeadRelIpd = true;
 // Same fix applied to the VR mouse cursor's per-eye stereo offset, which also lived on the airframe's right axis
 // (measured ~634px of eye-to-eye cursor split aiming at the lower-left panel vs ~226px near centre). 0 = legacy.
 bool g_bVrHeadRelCursorIpd = true;
+// And the same for the RTT display panels' per-eye offset, which went onto Pan.y (body right). This one is driven by
+// g_fVrDisplayIpd on its own code path, so neither VrHeadRelIpd nor VrViewInstIpdSign affects it -- it shows up as the
+// MFDs/aux consoles going cross-eyed as the head turns while the rest of the pit converges. 0 = legacy body axis.
+bool g_bVrHeadRelDisplayIpd = true;
 // Vulkan multiview only: rotate the per-view IPD (worldOffs) by cameraRot rather than ownshipRot. Unlike the per-eye
 // path, one worldOffs serves both the stage-1 world/cockpit and the stage-2 RTT tail, so this is a genuine trade --
 // on = correct convergence as the head turns; off = the flat-canvas RTT panel error stays head-independent. Default
@@ -1785,6 +1789,8 @@ static ConfigOption<bool> BoolOpts[] = {
      &g_bVrHeadRelIpd}, // per-eye IPD along the head's right axis, not the airframe's
     {"VrHeadRelCursorIpd",
      &g_bVrHeadRelCursorIpd}, // VR cursor stereo offset along the head's right axis, not the airframe's
+    {"VrHeadRelDisplayIpd",
+     &g_bVrHeadRelDisplayIpd}, // RTT display panel stereo offset along the head's right axis, not the airframe's
     {"VrVulkanHeadRelIpd",
      &g_bVrVulkanHeadRelIpd}, // Vulkan multiview: per-view IPD by cameraRot, not ownshipRot (default off)
     {"VrViewInstancing",

--- a/src/ui/src/f4config.cpp
+++ b/src/ui/src/f4config.cpp
@@ -90,6 +90,11 @@ bool g_bVrHeadRelIpd = true;
 // Same fix applied to the VR mouse cursor's per-eye stereo offset, which also lived on the airframe's right axis
 // (measured ~634px of eye-to-eye cursor split aiming at the lower-left panel vs ~226px near centre). 0 = legacy.
 bool g_bVrHeadRelCursorIpd = true;
+// Vulkan multiview only: rotate the per-view IPD (worldOffs) by cameraRot rather than ownshipRot. Unlike the per-eye
+// path, one worldOffs serves both the stage-1 world/cockpit and the stage-2 RTT tail, so this is a genuine trade --
+// on = correct convergence as the head turns; off = the flat-canvas RTT panel error stays head-independent. Default
+// off, i.e. the shipped behaviour. Has no effect on D3D12 or the per-eye path.
+bool g_bVrVulkanHeadRelIpd = false;
 // IPD sign for the per-eye view matrices built for the VI pass (headset-tuned: flip to -1 if the eyes swap).
 float g_fVrViewInstIpdSign = 1.0f;
 // #DX12 п.5: intermediate VR sky fix under VI -- give the QUAD FOCUS group its off-axis for the 2D-screen sky so it
@@ -1780,6 +1785,8 @@ static ConfigOption<bool> BoolOpts[] = {
      &g_bVrHeadRelIpd}, // per-eye IPD along the head's right axis, not the airframe's
     {"VrHeadRelCursorIpd",
      &g_bVrHeadRelCursorIpd}, // VR cursor stereo offset along the head's right axis, not the airframe's
+    {"VrVulkanHeadRelIpd",
+     &g_bVrVulkanHeadRelIpd}, // Vulkan multiview: per-view IPD by cameraRot, not ownshipRot (default off)
     {"VrViewInstancing",
      &g_bVrViewInstancing}, // Artscout - 2026: #DX12 п.5 single-pass stereo via view instancing (SM6.1/DXC)
     {"VrVulkanMultiview",

--- a/src/ui/src/f4config.cpp
+++ b/src/ui/src/f4config.cpp
@@ -221,7 +221,12 @@ bool g_bVrControllers = true; // master on/off. FFViper.cfg "VrControllers".
 float g_fVrRayRadius =
     2.0f; // hit radius = button.dist * this (button units). FFViper.cfg "VrRayRadius".
 float g_fVrRayReach =
-    300.0f; // free-cursor reach along the ray when nothing is hit (button units). "VrRayReach".
+    814.0f; // free-cursor reach along the ray when nothing is hit (button units). "VrRayReach".
+// 814 = the F-16 panel plane at the default seat position. This is the depth the free-aim cursor sits at with
+// nothing under it, so it wants to be ON the panel: at the previous 300 the cursor floated well in front of the
+// pit, carrying stereo disparity for a depth nothing occupies, and visibly split in two. It also re-centres the
+// dPt acceptance window in VCock_Exec ([0.6x, 1.6x] = [488, 1302], which brackets the panel; [180, 480] did not).
+// Controller users who want a shorter free ray can set it back in FFViper.cfg.
 // Artscout - 2026 (#58 true 3D mouse): sign/scale of the mouse ray's horizontal/vertical NDC->frustum-tangent
 // mapping. 1 = direct; -1 flips that axis if the cursor moves mirrored in-headset. Tune in FFViper.cfg then bake.
 float g_fVrMouseRayX = 1.0f;

--- a/src/ui/src/f4config.cpp
+++ b/src/ui/src/f4config.cpp
@@ -82,6 +82,14 @@ bool g_bVrStereoOffAxis = true;
 // Artscout - 2026: put the eyes' SHARED vertical off-axis into the base (CPU sky / 2D-screen) projection under stereo
 // off-axis. 0 = base stays symmetric -- use it if the HUD/RTT symbology sits vertically off.
 bool g_bVrStereoSkyOffAxis = true;
+// Apply the per-eye IPD along the HEAD's right axis rather than the airframe's. The eyes are separated across the
+// skull, so that separation rotates with the head; the old path added it to body-right and rotated by ownshipRot
+// (the JET's orientation, which holds no head rotation), so it was only correct looking straight ahead and drifted
+// as the head turned. Companion to VrEyeLatHeadFrame: that one fixes the MAGNITUDE, this one the AXIS. 0 = legacy.
+bool g_bVrHeadRelIpd = true;
+// Same fix applied to the VR mouse cursor's per-eye stereo offset, which also lived on the airframe's right axis
+// (measured ~634px of eye-to-eye cursor split aiming at the lower-left panel vs ~226px near centre). 0 = legacy.
+bool g_bVrHeadRelCursorIpd = true;
 // IPD sign for the per-eye view matrices built for the VI pass (headset-tuned: flip to -1 if the eyes swap).
 float g_fVrViewInstIpdSign = 1.0f;
 // #DX12 п.5: intermediate VR sky fix under VI -- give the QUAD FOCUS group its off-axis for the 2D-screen sky so it
@@ -1763,6 +1771,10 @@ static ConfigOption<bool> BoolOpts[] = {
      &g_bVrStereoOffAxis}, // Artscout - 2026: true per-view off-axis fov in stereo (0 = old symmetric)
     {"VrStereoSkyOffAxis",
      &g_bVrStereoSkyOffAxis}, // Artscout - 2026: shared vertical off-axis in the base (CPU sky) projection
+    {"VrHeadRelIpd",
+     &g_bVrHeadRelIpd}, // per-eye IPD along the head's right axis, not the airframe's
+    {"VrHeadRelCursorIpd",
+     &g_bVrHeadRelCursorIpd}, // VR cursor stereo offset along the head's right axis, not the airframe's
     {"VrViewInstancing",
      &g_bVrViewInstancing}, // Artscout - 2026: #DX12 п.5 single-pass stereo via view instancing (SM6.1/DXC)
     {"VrVulkanMultiview",

--- a/tools/registry/FreeFalcon6-registry.reg
+++ b/tools/registry/FreeFalcon6-registry.reg
@@ -1,0 +1,31 @@
+Windows Registry Editor Version 5.00
+
+; FreeFalcon 6 registry keys
+;
+; This build reads its data paths from the Falcon "4.1" key rather than "4.0", so it
+; does not collide with a stock Falcon 4.0 / GOG install that owns the 4.0 key.
+;
+; The paths below assume the install is at C:\FreeFalcon6.
+; IF YOURS IS ELSEWHERE, edit every path below before importing
+; (or just run install-registry.bat, which fills them in automatically).
+;
+; Note the WOW6432Node in the key path: the game opens this key with KEY_WOW64_32KEY,
+; i.e. the 32-bit registry view, even though the exe is 64-bit. That is deliberate --
+; do not "fix" it to the native path or the game will not find its data.
+;
+; Importing writes to HKEY_LOCAL_MACHINE and therefore requires administrator rights.
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\MicroProse\Falcon\4.1]
+"baseDir"="C:\FreeFalcon6"
+"misctexDir"="C:\FreeFalcon6\terrdata\misctex"
+"objectDir"="C:\FreeFalcon6\terrdata\objects"
+"theaterDir"="C:\FreeFalcon6\terrdata\korea"
+"movieDir"="C:\FreeFalcon6"
+"curTheater"="Korea"
+"FFver"="6.0"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\MicroProse\Falcon\4.1\MPR]
+"MPRDetect3Dx"=dword:00000001
+"MPRDetectCPU"=dword:00000001
+"MPRDetectMMX"=dword:00000001
+"MPRDetectXMM"=dword:00000001

--- a/tools/registry/install-registry.bat
+++ b/tools/registry/install-registry.bat
@@ -1,0 +1,102 @@
+@echo off
+setlocal EnableExtensions
+rem ---------------------------------------------------------------------------
+rem  FreeFalcon 6 registry setup / migration
+rem
+rem  This build reads its data paths from the Falcon "4.1" key instead of "4.0",
+rem  so FreeFalcon and a stock Falcon 4.0 / GOG install can coexist -- each owns
+rem  its own key instead of fighting over 4.0.
+rem
+rem  If you ALREADY had FreeFalcon working, your paths are under 4.0 and this
+rem  script copies them to 4.1 for you (nothing under 4.0 is changed or removed).
+rem
+rem  Usage: put next to FFViper.exe, right-click -> "Run as administrator".
+rem         install-registry.bat            migrate, or create from this folder
+rem         install-registry.bat /force     overwrite 4.1 paths with this folder
+rem
+rem  /reg:32 targets the 32-bit registry view (WOW6432Node) -- the game opens the
+rem  key with KEY_WOW64_32KEY even though the exe is 64-bit. Do not remove it.
+rem ---------------------------------------------------------------------------
+
+set "BASE=%~dp0"
+if "%BASE:~-1%"=="\" set "BASE=%BASE:~0,-1%"
+set "OLD=HKLM\SOFTWARE\MicroProse\Falcon\4.0"
+set "NEW=HKLM\SOFTWARE\MicroProse\Falcon\4.1"
+set "FORCE="
+if /i "%~1"=="/force" set "FORCE=1"
+
+net session >nul 2>&1
+if errorlevel 1 (
+  echo ERROR: must be run as administrator ^(writes to HKEY_LOCAL_MACHINE^).
+  echo Right-click install-registry.bat -^> "Run as administrator".
+  pause & exit /b 1
+)
+
+echo FreeFalcon folder detected as:
+echo     %BASE%
+echo.
+if not exist "%BASE%\FFViper.exe" (
+  echo WARNING: FFViper.exe not found here. This script should sit in your
+  echo          FreeFalcon folder. Continuing anyway.
+  echo.
+)
+
+reg query "%NEW%" /v baseDir /reg:32 >nul 2>&1
+if not errorlevel 1 if not defined FORCE (
+  echo The 4.1 key already exists:
+  echo.
+  reg query "%NEW%" /reg:32
+  echo.
+  echo Nothing changed. Re-run with /force to reset the paths to this folder.
+  pause & exit /b 0
+)
+
+if defined FORCE goto :writefresh
+
+rem --- migrate an existing FreeFalcon install from 4.0 -----------------------
+reg query "%OLD%" /v baseDir /reg:32 >nul 2>&1
+if errorlevel 1 goto :writefresh
+
+for /f "tokens=2,*" %%A in ('reg query "%OLD%" /v baseDir /reg:32 ^| findstr /i baseDir') do set "OLDBASE=%%B"
+echo Found an existing Falcon 4.0 key pointing at:
+echo     %OLDBASE%
+echo.
+if /i "%OLDBASE%"=="%BASE%" (
+  echo That is this same folder, so it is your existing FreeFalcon install.
+) else (
+  echo NOTE: that is a DIFFERENT folder from this one. If it is a stock Falcon
+  echo       4.0 / GOG install rather than FreeFalcon, press Ctrl+C now and run
+  echo       this script again with /force to write this folder's paths instead.
+)
+echo.
+echo Copying 4.0 -^> 4.1 ^(4.0 is left untouched^)...
+reg copy "%OLD%" "%NEW%" /s /f /reg:32 >nul || goto :fail
+goto :done
+
+:writefresh
+echo Writing 4.1 keys from this folder...
+reg add "%NEW%" /v baseDir    /t REG_SZ /d "%BASE%"                  /reg:32 /f >nul || goto :fail
+reg add "%NEW%" /v misctexDir /t REG_SZ /d "%BASE%\terrdata\misctex" /reg:32 /f >nul || goto :fail
+reg add "%NEW%" /v objectDir  /t REG_SZ /d "%BASE%\terrdata\objects" /reg:32 /f >nul || goto :fail
+reg add "%NEW%" /v theaterDir /t REG_SZ /d "%BASE%\terrdata\korea"   /reg:32 /f >nul || goto :fail
+reg add "%NEW%" /v movieDir   /t REG_SZ /d "%BASE%"                  /reg:32 /f >nul || goto :fail
+reg add "%NEW%" /v curTheater /t REG_SZ /d "Korea"                   /reg:32 /f >nul || goto :fail
+reg add "%NEW%" /v FFver      /t REG_SZ /d "6.0"                     /reg:32 /f >nul || goto :fail
+reg add "%NEW%\MPR" /v MPRDetect3Dx /t REG_DWORD /d 1 /reg:32 /f >nul || goto :fail
+reg add "%NEW%\MPR" /v MPRDetectCPU /t REG_DWORD /d 1 /reg:32 /f >nul || goto :fail
+reg add "%NEW%\MPR" /v MPRDetectMMX /t REG_DWORD /d 1 /reg:32 /f >nul || goto :fail
+reg add "%NEW%\MPR" /v MPRDetectXMM /t REG_DWORD /d 1 /reg:32 /f >nul || goto :fail
+
+:done
+echo.
+echo Done. The 4.1 key now contains:
+echo.
+reg query "%NEW%" /reg:32
+echo.
+echo Your Falcon 4.0 key was not modified.
+pause & exit /b 0
+
+:fail
+echo.
+echo FAILED to write the registry. Are you running as administrator?
+pause & exit /b 1


### PR DESCRIPTION
# VR: finishing `VrStereoOffAxis` for plain-stereo hardware

`VrStereoOffAxis` (`b6a8453`) fixed the primary VR bug: plain stereo now renders and submits the
runtime's **true off-axis per-eye frustum**, as quad-views always has. This series finishes the job in
the places that still assumed the old symmetric-stereo geometry.

Reproduced and fixed on a **Meta Quest 3 over Quest Link** (Meta's native OpenXR runtime), D3D12 and
Vulkan, driving the pit with the **mouse** — no controllers. That input path is likely why these went
unnoticed: the ray/controller path does not go through `VrSetEyeCam`.

Everything defaults **on** except the one genuine trade-off (`VrVulkanHeadRelIpd`), and every fix has
its own knob.

---

## The two failure families

Everything below is one of two mistakes, each repeated in several independent code paths.

**A — a symmetric projection where the runtime wants off-axis.** A Quest 3 eye is canted ~7° outward
(`L=-54° R=+40°`, `U=+44° D=-55°`). Draw a 2D layer with a symmetric frustum on top of a 3D scene
drawn off-axis and the two disagree by that cant, mirrored per eye.

**B — the per-eye IPD applied along the airframe's right axis instead of the head's.** The eyes are
separated across the skull, so that separation rotates with the **head**. Body-right and head-right
coincide only while looking forward, so the error is zero at centre and grows with head rotation:
`ipd × 2·sin(θ/2)`, about 75% of the eye offset at 45° of gaze, and worst on the **closest** geometry.

Family B occurs in four places, each with its **own variable and code path** — fixing one does nothing
for the others, which is what made the last one hard to find:

| path | variable | knob |
|---|---|---|
| world camera (`VCock_HeadCalc`) | `g_fVrViewInstIpdSign` | `VrHeadRelIpd` |
| cursor anchor | `g_fVrRayIpd` | `VrHeadRelCursorIpd` |
| RTT display panels (`Pan.y`) | `g_fVrDisplayIpd` | `VrHeadRelDisplayIpd` |
| Vulkan multiview `worldOffs` | `g_fVrViewInstIpdSign` | `VrVulkanHeadRelIpd` |

---

## 1. Cursor and hit-test disagreed with the render (family A)

**Symptom.** Two cursors that will not fuse, and clicks landing on a different control than the one
under the cursor.

**1a.** The pick symmetrised the vertical frustum while keeping the horizontal off-axis — correct
against the old symmetric render. The pit is now drawn with the true vertically-canted frustum,
leaving projected buttons ~10% of screen height from where they are drawn. Now gated on
`g_bVrStereoOffAxis` and tracks the render.

**1b.** `VrSetEyeCam()` — which sets the projection the cursor glyph is drawn through — still
hard-coded `SetVRFrustum(-hh, hh, vhalf, -vhalf)` for stereo. Now mirrors the render.

`VrDetectBiasXStereoDx12` (default `-180.0f`) exists to paper over exactly this mismatch and should
now sit at its neutral value.

Files: `sim/otwdrive/vcock.cpp`

---

## 2. World camera IPD on the airframe axis (family B)

**Symptom.** Straight ahead converges; looking down-left / down-right at the aux panels goes
cross-eyed, worsening the further the head turns.

```cpp
posCam.y += GetEyeLateralOffsetFeet(xeye);            // body right
MatrixMult(&OTWDriver.ownshipRot, &posCam, &posW);    // aircraft orientation -- no head rotation
```

Head lean still goes through `ownshipRot` (it is a body-frame 6DOF translation); the per-eye IPD is
now rotated by `cameraRot` (`= ownshipRot * headMatrix`), matching what `RenderWorldViewInstanced`
already did with `camRot`.

### Relationship to `VrEyeLatHeadFrame`

Two halves of one problem, and **both are required**:

| | where | fixes |
|---|---|---|
| `VrEyeLatHeadFrame` | `openxrbackend.cpp` | the **magnitude** — projects the eye delta onto the head's right axis instead of raw `appSpace` X (which decays as `cos(yaw)` and flips sign past 90°) |
| `VrHeadRelIpd` | `vcock.cpp` | the **axis** — which direction that offset points in the world |

Verified on a Quest 3: with `VrEyeLatHeadFrame=1` alone, the drift remains. Worth considering
defaulting `VrEyeLatHeadFrame` to **on** — a headset reporting canted frusta is the case it exists for.

Files: `sim/otwdrive/vcock.cpp`

---

## 3. Cursor stereo offset and free-aim depth

**3a (family B).** The cursor anchor lives in cockpit/body space and its per-eye offset went straight
onto `.y`. Measured ~**634px** of eye-to-eye cursor split aiming at the lower-left panel versus ~226px
near centre. Now rotated by `headMatrix`.

**3b.** With no button hit, the anchor used `dPt` — the nearest button's projection *along the ray*
(`dist × cos θ`). Aimed off-panel that cosine collapses, parking the cursor nearer than anything real
and splitting it in two mid-screen, while `VrRayReach` never applied because some button is always
"nearest". `dPt` is now used only when it is actually near the panel plane.

`VrRayReach` is now the depth the free-aim cursor actually sits at, so its default moves from `300` to
**`814`** — the F-16 panel plane at the default seat position. At `300` the cursor floated well in
front of the pit and split in two whenever it was not over a control. It also re-centres the
acceptance window: `[0.6×, 1.6×]` is `[488, 1302]` at 814, which brackets the panel, where
`[180, 480]` excluded it and forced the fallback every time.

That default change is a **separate commit** and easy to drop — the knob predates this work (added for
VR controllers, where a shorter free ray may be wanted) and `FFViper.cfg` still overrides it.

Files: `sim/otwdrive/vcock.cpp`, `ui/src/f4config.cpp`

---

## 4. Vulkan: RTT tail pass drawn with a symmetric frustum (family A)

**Symptom.** Under Vulkan multiview the world fuses correctly, but MFD and HUD elements duplicate and
sit away from the panels they belong to.

`RenderVulkanVR` draws the world and 3D cockpit once into both layers (stage 1), then runs a per-eye
tail pass (stage 2) that calls `VCock_Exec` for the RTT displays and 2D overlays. `VrStereoOffAxis`
updated stage 1; stage 2 still gated its frustum on `quad` alone and fell through to a symmetric
`SetFOV(hf)`. Now gated on `quad or g_bVrStereoOffAxis` to match.

D3D12 view instancing is unaffected — its VI pass is world-only (stage 1a) and the cockpit and RTT go
through the ordinary per-eye path.

Files: `sim/otwdrive/otwloop.cpp`

---

## 5. Vulkan: head-frame IPD (family B, and a genuine trade-off)

`RenderVulkanVR` rotates its per-view IPD by `ownshipRot`, and the comment justifies it by pointing at
"the per-eye path, which puts the IPD in `headOrigin` via `ownshipRot*eyeLatFeet`" — the line #2 above
replaces. On a Quest 3 that produces exactly the family-B cross-eye once #4 is fixed.

It is **not** a straight port, though. The per-eye path can have it both ways because the world camera
IPD (`headOrigin`) and the RTT panel IPD (`Pan.y * g_fVrDisplayIpd`) are separate values. Here one
`worldOffs` feeds both the stage-1 world/cockpit and the stage-2 RTT tail, so head-frame fixes the
convergence but rotates the flat-canvas panel error with the head — the drift the original comment set
out to avoid.

So this ships as `VrVulkanHeadRelIpd`, **default off** (shipped behaviour). On this hardware `1` is
clearly better, but that is one headset. The real fix is to decouple the two consumers the way the
per-eye path does.

Files: `sim/otwdrive/otwloop.cpp`, `ui/src/f4config.cpp`

---

## 6. RTT display panels' IPD on the airframe axis (family B)

**Symptom.** With everything above fixed, the MFDs and lower-left/right consoles still go cross-eyed
as the head turns while the rest of the pit converges.

```cpp
Pan.y += GetEyeLateralOffsetFeet(dxeye) * g_fVrDisplayIpd;   // body right
```

This path is driven by `g_fVrDisplayIpd` and is separate from the world camera IPD, so neither
`VrHeadRelIpd` nor `g_fVrViewInstIpdSign` affects it. `Pan` is cockpit/body space, so the head-frame
offset is now rotated into it by `headMatrix`, exactly as the cursor anchor fix does.

**How it was isolated** (useful for the next one of these): setting `g_fVrViewInstIpdSign -1` swapped
the eyes and cross-eyed the entire cockpit as expected, **while leaving the lower-left/right panels off
by exactly the same amount as before**. That immunity proved a second, independent contributor and
pointed straight at it.

Files: `sim/otwdrive/vcock.cpp`, `ui/src/f4config.cpp`

---

## Registry key: `4.0` → `4.1`

**Breaking change for existing Windows installs**, in a separate commit that is easy to drop.

`FALCON_REGISTRY_KEY` (duplicated in `falclib/include/f4find.h` and `sim/include/datadir.h`) pointed at
`Software\MicroProse\Falcon\4.0`, the stock Falcon 4.0 key. On a machine with both installed the two
fight over one key and FreeFalcon loads the wrong data tree. Reading `4.1` lets them coexist.

`tools/registry/` carries a `.reg` template and `install-registry.bat`, which migrates an existing
`4.0` install by copying its values to `4.1` (handling `WOW6432Node` redirection). It does not modify
or remove the `4.0` key.

---

## Configuration

Every fix defaults on except `VrVulkanHeadRelIpd`. Reverts, individually:

```
set g_bVrHeadRelIpd 0         # revert #2
set g_bVrHeadRelCursorIpd 0   # revert #3a
set g_bVrHeadRelDisplayIpd 0  # revert #6
set g_fVrRayReach 300         # previous free-aim cursor depth
set g_bVrVulkanHeadRelIpd 1   # opt IN to #5 (default off)
```

#1 and #4 follow `VrStereoOffAxis` — turning that off restores the old symmetric behaviour throughout,
render and 2D layers together.

---

## Verified

Quest 3 / Quest Link / mouse cursor, on top of `ed464a81`:

**D3D12**, `VrEyeLatHeadFrame 1`, `VrViewInstancing 0`, `VrD3D12ViCockpit 0`:
- single fused cursor; clicks land where the cursor is, across the whole pit
- no cross-eye looking down-left / down-right, including the MFDs and lower consoles
- every switch in the pit tracks and clicks correctly

**Vulkan**, same plus `VrVulkanHeadRelIpd 1`:
- MFDs and HUD sit on their panels and fuse
- no gaze-dependent cross-eye

---

## Known remaining issues

- **View instancing still shows cross-eye** (`VrViewInstancing 1`, which is the **default**). Not
  investigated to root cause. Prime suspect is the shared base projection for stereo,
  `SetVRFrustum(-hf * 0.5f, hf * 0.5f, fu0, fd0)` — horizontally symmetric, so anything CPU-projected
  through it (sky, 2D-screen path) gets no per-eye cant while GPU geometry gets correct per-view
  `projs`. Structurally the same defect as #4, one layer over.
- **Terrain tile pop-in at the outer edges on fast head turns.** Not the activation budget — setting
  `TileActivatePerFrame`/`TileActivateMeshPerFrame` to unlimited changed nothing, so the tiles are not
  being *requested*, not merely throttled. Suspect the re-scan region that decides which posts ask for
  tiles.
- **Free-aim cursor separates slightly** over a few small patches of non-clickable geometry. Cosmetic;
  a proper fix would anchor to the depth of whatever the ray strikes rather than one panel-plane
  constant.
- **External views have no head tracking.** Every HMD pose consumer is gated to cockpit display modes,
  so in the external/orbit views (9/0) the scene renders from a head-unaware camera while the real head
  pose is still submitted to the compositor.

---

## Testing caveat

One headset, one input path (Quest 3 / Quest Link / mouse). The quad-views and controller paths are
untouched by design, but that is a claim about the code, not a tested result.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
